### PR TITLE
Add marriage and divorce rules

### DIFF
--- a/assets/doc/about.md
+++ b/assets/doc/about.md
@@ -41,6 +41,10 @@ two cards of the same rank with another card between them; for example 6-3-6.
 or decreasing rank are played, for example 8-7-6 or 9-10-jack. Aces can be high or low and can
 "wrap around", so players can slap on king-ace-2.
 - **Slap on 4 of same suit**: If enabled, players can slap the pile when 4 cards of the same suit
+- **Slap on marriages**: If enabled, players can slap the pile when a "marriages" occurs, which is
+when a king and queen are played consecutively.
+- **Slap on divorces**: If enabled, players can slap the pile when a "divorce" occurs, which is
+when a king and queen are played with another card between them.
 suit are played.
 - **Penalty for wrong slap**: Allows you to choose the penalty if a player slaps incorrectly.
 "Penalty card" causes the offending player to put a card on the bottom of the current pile.

--- a/lib/game.dart
+++ b/lib/game.dart
@@ -72,6 +72,8 @@ enum RuleVariation {
   slap_on_run_of_3,
   slap_on_same_suit_of_4,
   slap_on_add_to_10,
+  slap_on_marriage,
+  slap_on_divorce,
 }
 
 // Penalty options for incorrect slaps.
@@ -257,6 +259,20 @@ class Game {
       final r1 = pileCards[ps - 1].card.rank.numericValue;
       final r2 = pileCards[ps - 2].card.rank.numericValue;
       if (r1 + r2 == 10) {
+        return true;
+      }
+    }
+    if (rules.isVariationEnabled(RuleVariation.slap_on_marriage) && ps >= 2) {
+      final r1 = pileCards[ps - 1].card.rank;
+      final r2 = pileCards[ps - 2].card.rank;
+      if ((r1 == Rank.king && r2 == Rank.queen) || (r1 == Rank.queen && r2 == Rank.king)) {
+        return true;
+      }
+    }
+    if (rules.isVariationEnabled(RuleVariation.slap_on_divorce) && ps >= 3) {
+      final r1 = pileCards[ps - 1].card.rank;
+      final r3 = pileCards[ps - 3].card.rank;
+      if ((r1 == Rank.king && r3 == Rank.queen) || (r1 == Rank.queen && r3 == Rank.king)) {
         return true;
       }
     }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -936,6 +936,8 @@ class _MyHomePageState extends State<MyHomePage> {
                           '4 of same suit', RuleVariation.slap_on_same_suit_of_4),
                       makeRuleCheckboxRow(
                           'Adds to 10', RuleVariation.slap_on_add_to_10),
+                      makeRuleCheckboxRow('Marriages', RuleVariation.slap_on_marriage),
+                      makeRuleCheckboxRow('Divorces', RuleVariation.slap_on_divorce),
 
                       TableRow(children: [Container(height: 10)]),
 

--- a/test/game_test.dart
+++ b/test/game_test.dart
@@ -207,4 +207,35 @@ void main() {
       expect(game.canSlapPile(), false, reason: 'Wrong at index $i');
     }
   });
+
+  test('handles marriage slaps', () {
+    final game = Game();
+    game.rules.setVariationEnabled(RuleVariation.slap_on_marriage, true);
+    game.playerCards = [
+      cards('4S QH QD KC 6S'),
+      cards('KD 8C KH QS 4S'),
+    ];
+
+    // Play should go 4S-KD-QH(*)-8C-QD-KH(*)-KC(pair)-QS(*).
+    final slapIndices = {2, 5, 6, 7};
+    for (var i = 0; i < 8; i++) {
+      game.playCard();
+      expect(game.canSlapPile(), slapIndices.contains(i), reason: 'Wrong at index $i');
+    }
+  });
+
+  test('handles divorce slaps', () {
+    final game = Game();
+    game.rules.setVariationEnabled(RuleVariation.slap_on_divorce, true);
+    game.playerCards = [
+      cards('KS 4H KD 6C QS 6D'),
+      cards('7D QC 8H KH 4S KC'),
+    ];
+    // Play should go KS-7D-QC(*)-4H-KD(*)-8H-KH-6C-QS(*)-4S-KC(*)
+    final slapIndices = {2, 4, 8, 10};
+    for (var i = 0; i < 11; i++) {
+      game.playCard();
+      expect(game.canSlapPile(), slapIndices.contains(i), reason: 'Wrong at index $i');
+    }
+  });
 }


### PR DESCRIPTION
marriages - when a king and queen are played consecutively.
divorces - when a king and queen are played with another card between them.