### PR TITLE
use activeCards for testing the slap rules

### DIFF
--- a/lib/game.dart
+++ b/lib/game.dart
@@ -260,22 +260,22 @@ class Game {
       }
     }
     if (rules.isVariationEnabled(RuleVariation.slap_on_add_to_10) && ps >= 2) {
-      final r1 = pileCards[ps - 1].card.rank.numericValue;
-      final r2 = pileCards[ps - 2].card.rank.numericValue;
+      final r1 = activeCards[ps - 1].card.rank.numericValue;
+      final r2 = activeCards[ps - 2].card.rank.numericValue;
       if (r1 + r2 == 10) {
         return true;
       }
     }
     if (rules.isVariationEnabled(RuleVariation.slap_on_marriage) && ps >= 2) {
-      final r1 = pileCards[ps - 1].card.rank;
-      final r2 = pileCards[ps - 2].card.rank;
+      final r1 = activeCards[ps - 1].card.rank;
+      final r2 = activeCards[ps - 2].card.rank;
       if ((r1 == Rank.king && r2 == Rank.queen) || (r1 == Rank.queen && r2 == Rank.king)) {
         return true;
       }
     }
     if (rules.isVariationEnabled(RuleVariation.slap_on_divorce) && ps >= 3) {
-      final r1 = pileCards[ps - 1].card.rank;
-      final r3 = pileCards[ps - 3].card.rank;
+      final r1 = activeCards[ps - 1].card.rank;
+      final r3 = activeCards[ps - 3].card.rank;
       if ((r1 == Rank.king && r3 == Rank.queen) || (r1 == Rank.queen && r3 == Rank.king)) {
         return true;
       }


### PR DESCRIPTION
Hi,
thanks for creating and sharing this game!
I wanted to add a few custom rules to it and noticed that some of the rules are implemented wrongly, because they use the whole game pile, including penalty cards, but the offset from the active card pile. So they don't compare the latest 2 cards but older cards as soon as a penalty card was added.